### PR TITLE
Include unity-control-center for high-DPI screens

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -542,6 +542,7 @@ tcptrace
 tofrodos
 torsocks
 transmission
+unity-control-center
 unrar
 upx-ucl
 vbindiff


### PR DESCRIPTION
Closes https://github.com/sans-dfir/sift/issues/58, at least for the bootstrap.sh file. Note this will still need to be fixed in deployed SIFT versions.
